### PR TITLE
Feature: #243 Created Model selection response

### DIFF
--- a/backend/app/dto/response.py
+++ b/backend/app/dto/response.py
@@ -83,3 +83,8 @@ class ResultResponse(BaseModel):
     type: str = "RESULT"
     state: ScenarioStateDTO
     # ToDo: Add result stats (Issue #237)
+
+
+class ModelSelectionResponse(ScenarioResponse):
+    type: str = "MODEL"
+    models: List[str]

--- a/backend/app/models/model_selection.py
+++ b/backend/app/models/model_selection.py
@@ -1,0 +1,22 @@
+from django.db import models
+
+from app.models.template_scenario import TemplateScenario
+
+
+class ModelSelection(models.Model):
+    index = models.PositiveIntegerField()
+    text = models.TextField()
+    waterfall = models.BooleanField(default=True)
+    kanban = models.BooleanField(default=True)
+    scrum = models.BooleanField(default=True)
+
+    template_scenario = models.ForeignKey(
+        TemplateScenario,
+        on_delete=models.CASCADE,
+        related_name="model_selections",
+        blank=True,
+        null=True,
+    )
+
+    def models(self):
+        return [m for m in ["waterfall", "scrum", "kanban"] if self.__getattribute__(m)]

--- a/backend/app/serializers/model_selection.py
+++ b/backend/app/serializers/model_selection.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from app.models.action import Action
+from app.models.model_selection import ModelSelection
+
+
+class ModelSelectionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ModelSelection
+        fields = "__all__"

--- a/backend/app/serializers/template_scenario.py
+++ b/backend/app/serializers/template_scenario.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from app.exceptions import IndexException
 from app.models.action import Action
 from app.models.answer import Answer
+from app.models.model_selection import ModelSelection
 from app.models.management_goal import ManagementGoal
 from app.models.question import Question
 from app.models.question_collection import QuestionCollection
@@ -14,6 +15,7 @@ from app.models.simulation_fragment import SimulationFragment
 from app.models.template_scenario import TemplateScenario
 from app.serializers.management_goal import ManagementGoalSerializer
 from app.serializers.question_collection import QuestionCollectionSerializer
+from app.serializers.model_selection import ModelSelectionSerializer
 from app.serializers.score_card import ScoreCardSerializer
 from app.serializers.simulation_fragment import SimulationFragmentSerializer
 from app.src.util.scenario_util import check_indexes
@@ -23,6 +25,7 @@ class TemplateScenarioSerializer(serializers.ModelSerializer):
     management_goal = ManagementGoalSerializer()
     question_collections = QuestionCollectionSerializer(many=True)
     simulation_fragments = SimulationFragmentSerializer(many=True)
+    model_selections = ModelSelectionSerializer(many=True)
     score_card = ScoreCardSerializer()
 
     class Meta:
@@ -33,6 +36,7 @@ class TemplateScenarioSerializer(serializers.ModelSerializer):
             "management_goal",
             "question_collections",
             "simulation_fragments",
+            "model_selections",
             "score_card",
         )
 
@@ -51,6 +55,7 @@ class TemplateScenarioSerializer(serializers.ModelSerializer):
         management_goal_data = validated_data.pop("management_goal")
         question_collection_data = validated_data.pop("question_collections")
         simulation_fragments_data = validated_data.pop("simulation_fragments")
+        model_selections_data = validated_data.pop("model_selections")
         score_card_data = validated_data.pop("score_card")
 
         # 0. create template scenario
@@ -63,7 +68,7 @@ class TemplateScenarioSerializer(serializers.ModelSerializer):
             template_scenario = TemplateScenario.objects.create(**validated_data)
 
         # 1. create management_goal
-        management_goal = ManagementGoal.objects.create(
+        ManagementGoal.objects.create(
             template_scenario=template_scenario, **management_goal_data
         )
 
@@ -103,7 +108,7 @@ class TemplateScenarioSerializer(serializers.ModelSerializer):
                 template_scenario=template_scenario, **simulation_fragment_data
             )
 
-            simulation_end = SimulationEnd.objects.create(
+            SimulationEnd.objects.create(
                 simulation_fragment=simulation_fragment, **simulation_end_data
             )
 
@@ -115,9 +120,13 @@ class TemplateScenarioSerializer(serializers.ModelSerializer):
                 )
 
         # 4. create score card
-        score_card = ScoreCard.objects.create(
-            template_scenario=template_scenario, **score_card_data
-        )
+        ScoreCard.objects.create(template_scenario=template_scenario, **score_card_data)
+
+        # 5. create model selections
+        for model_selection in model_selections_data:
+            ModelSelection.objects.create(
+                **model_selection, template_scenario=template_scenario
+            )
 
         return template_scenario
 

--- a/backend/app/src/simulation.py
+++ b/backend/app/src/simulation.py
@@ -2,6 +2,7 @@ import logging
 
 
 from app.dto.response import (
+    ModelSelectionResponse,
     SimulationResponse,
     QuestionResponse,
     ScenarioResponse,
@@ -12,6 +13,7 @@ from app.models.question_collection import QuestionCollection
 from app.models.simulation_fragment import SimulationFragment
 from app.models.user_scenario import UserScenario
 from app.models.task import Task
+from app.models.model_selection import ModelSelection
 from app.src.util.question_util import get_question_collection
 from app.src.util.task_util import get_tasks_status
 from app.src.util.member_util import get_member_report
@@ -120,4 +122,13 @@ def continue_simulation(
             tasks=get_tasks_status(scenario.id),
             state=get_scenario_state_dto(scenario),
             members=get_member_report(scenario.team.id),
+        )
+    # Check if next component is a Model Selection
+    if isinstance(next_component, ModelSelection):
+        increase_scenario_counter(scenario)
+        return ModelSelectionResponse(
+            tasks=get_tasks_status(scenario.id),
+            state=get_scenario_state_dto(scenario),
+            members=get_member_report(scenario.team.id),
+            models=next_component.models(),
         )

--- a/backend/app/src/util/scenario_util.py
+++ b/backend/app/src/util/scenario_util.py
@@ -1,11 +1,13 @@
 def check_indexes(data) -> bool:
 
     index_list = []
-    for question_collection in data.get("question_collections"):
-        index_list.append(question_collection.get("index"))
-
-    for simulation_fragment in data.get("simulation_fragments"):
-        index_list.append(simulation_fragment.get("index"))
+    for component_type in [
+        "question_collections",
+        "simulation_fragments",
+        "model_selections",
+    ]:
+        for component_data in data.get(component_type):
+            index_list.append(component_data.get("index"))
 
     sorted_index_list = sorted(index_list)
     for i in range(0, len(sorted_index_list)):

--- a/backend/app/src/util/user_scenario_util.py
+++ b/backend/app/src/util/user_scenario_util.py
@@ -1,6 +1,7 @@
 from app.dto.response import ScenarioStateDTO, ResultResponse
 from app.models.question_collection import QuestionCollection
 from app.models.simulation_fragment import SimulationFragment
+from app.models.model_selection import ModelSelection
 from app.models.task import Task
 from app.models.user_scenario import UserScenario
 from app.serializers.user_scenario import ScenarioStateSerializer
@@ -19,16 +20,15 @@ def find_next_scenario_component(scenario):
     # todo: find better solution
 
     # add all components here
-    components = [QuestionCollection, SimulationFragment]
+    components = [QuestionCollection, SimulationFragment, ModelSelection]
+    query = dict(
+        index=scenario.state.counter, template_scenario_id=scenario.template_id
+    )
 
     for component in components:
-        if component.objects.filter(
-            index=scenario.state.counter, template_scenario_id=scenario.template_id
-        ).exists():
-            # return an instance of the component -> gets checked with isinstance() in continue_simulation function
-            return component()
-        else:
-            pass
+        if component.objects.filter(**query).exists():
+            # return the next component instance -> gets checked with isinstance() in continue_simulation function
+            return component.objects.get(**query)
 
     # send ResultResponse when scenario is finished
     return ResultResponse(state=get_scenario_state_dto(scenario))


### PR DESCRIPTION
Created `ModelSelection` and improved some bits in the code to make them more simple.

Now we can create model selections as standard components, just like sim fragments and question collections. 

e.g:
```json
"model_selections": [
    {
      "index": 0,
      "text": "Auch **Markdown** geht!",
      "waterfall": true,
      "kanban": false,
      "scrum": true
    }
]
```

The three bool-attributes `waterfall`, `kanban` and `scrum` state if the respective model should be selectable by the user. 

When a Model Selection is the active component in an ongoing simulation, the response has type `MODEL` and looks like this: models is just a list of strings of the available choices, and the rest is the standard SceanrioResponse data.

```json
{
    "type": "MODEL",
    "models": [
        "waterfall",
        "scrum"
    ],
    "state": {
        "counter": 1,
        "day": 0,
        "cost": 0.0
    },
    "tasks": {
        "tasks_todo": 1350,
        "task_done": 0,
        "tasks_unit_tested": 0,
        "tasks_integration_tested": 0,
        "tasks_bug": 0
    },
    "members": []
}
```


#260 deals with the implantation of the Body format of the POST Request answering a model selection