### PR TITLE
task: #279 check if request type matches previous response type

### DIFF
--- a/backend/app/api/views/simulation.py
+++ b/backend/app/api/views/simulation.py
@@ -13,6 +13,7 @@ from app.exceptions import (
     RequestTypeException,
     RequestActionException,
     RequestMembersException,
+    RequestTypeMismatchException,
 )
 from app.models.scenario import ScenarioConfig
 from django.core.exceptions import ObjectDoesNotExist
@@ -139,6 +140,7 @@ class NextStepView(APIView):
             RequestTypeException,
             RequestActionException,
             RequestMembersException,
+            RequestTypeMismatchException,
         ) as e:
             return Response(
                 {"status": "error", "error-message": str(e)},

--- a/backend/app/dto/request.py
+++ b/backend/app/dto/request.py
@@ -59,3 +59,7 @@ class QuestionRequest(ScenarioRequest):
 
 class ModelRequest(ScenarioRequest):
     """not finished, just shell"""
+
+
+class StartRequest(ScenarioRequest):
+    """not finished, just shell"""

--- a/backend/app/dto/response.py
+++ b/backend/app/dto/response.py
@@ -38,7 +38,8 @@ class QuestionCollectionDTO(BaseModel):
 
 
 class ScenarioStateDTO(BaseModel):
-    counter: int
+    component_counter: int
+    step_counter: int
     day: int
     cost: float
 

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -29,3 +29,10 @@ class RequestMembersException(BaseException):
 
 class SimulationException(BaseException):
     """Raised when simulation cannot be executed because of wrong data in request."""
+
+
+class RequestTypeMismatchException(BaseException):
+    """Raised when request type does not match response type of last step in history."""
+
+    def __init__(self, type):
+        super().__init__(f"Request type {type} does not match previous response type.")

--- a/backend/app/models/user_scenario.py
+++ b/backend/app/models/user_scenario.py
@@ -8,7 +8,13 @@ from custom_user.models import User
 
 
 class ScenarioState(models.Model):
-    counter = models.IntegerField(default=0)
+
+    # counter for the components of the scenario
+    component_counter = models.IntegerField(default=0)
+
+    # counter for each step of the scenario simulation
+    step_counter = models.IntegerField(default=0)
+
     cost = models.FloatField(default=0)
     day = models.IntegerField(default=0)
 

--- a/backend/app/serializers/user_scenario.py
+++ b/backend/app/serializers/user_scenario.py
@@ -10,7 +10,7 @@ from app.serializers.template_scenario import TemplateScenarioSerializer
 class ScenarioStateSerializer(serializers.ModelSerializer):
     class Meta:
         model = ScenarioState
-        fields = ["counter", "cost", "day"]
+        fields = ["component_counter", "step_counter", "cost", "day"]
 
 
 class UserScenarioSerializer(serializers.ModelSerializer):

--- a/backend/app/src/simulation.py
+++ b/backend/app/src/simulation.py
@@ -15,6 +15,7 @@ from app.exceptions import (
     RequestTypeException,
     RequestActionException,
     RequestMembersException,
+    RequestTypeMismatchException,
 )
 from app.models.question_collection import QuestionCollection
 from app.models.simulation_fragment import SimulationFragment
@@ -22,14 +23,19 @@ from app.models.user_scenario import UserScenario
 from app.models.task import Task
 from app.models.model_selection import ModelSelection
 from app.src.util.question_util import get_question_collection, handle_question_answers
-from app.src.util.scenario_util import handle_model_request
+from app.src.util.scenario_util import (
+    handle_model_request,
+    handle_start_request,
+    request_type_matches_previous_response_type,
+)
 from app.src.util.task_util import get_tasks_status
 from app.src.util.member_util import get_member_report
 from app.src.util.user_scenario_util import (
     get_scenario_state_dto,
     find_next_scenario_component,
     end_of_fragment,
-    increase_scenario_counter,
+    increase_scenario_component_counter,
+    increase_scenario_step_counter,
 )
 from app.models.team import SkillType
 from app.models.team import Member
@@ -98,73 +104,76 @@ def continue_simulation(scenario: UserScenario, req) -> ScenarioResponse:
     :param req: Object with request data
 
     """
+    # response that gets returned at the end
+    scenario_response = None
+
     # 1. Process the request information
-    # check if request type is specified. might not be needed here anymore,
+    # 1.1 check if request type is specified. might not be needed here anymore,
     # since it is already checked in simulation view.
     if req.type is None:
         raise RequestTypeException()
 
-    # handle the request data
+    # 1.2 check if request type matches previous response type
+    if not request_type_matches_previous_response_type(scenario, req):
+        raise RequestTypeMismatchException(req.type)
+
+    # 1.3 handle the request data
     request_handling_mapper = {
         "SIMULATION": simulate,
         "QUESTION": handle_question_answers,
         "MODEL": handle_model_request,
+        "START": handle_start_request,
     }
     request_handling_mapper[req.type](req, scenario)
 
-    write_history(scenario, req)
+    # 2. Check if Simulation Fragment ended
+    # if fragment ended -> increase counter -> next component will be loaded in next step
+    if end_of_fragment(scenario):
+        logging.info(
+            f"Fragment with index {scenario.state.component_counter} has ended."
+        )
+        increase_scenario_component_counter(scenario)
 
-    # 2. Find next component
+    # 3. Find next component
     # find next component depending on current index of the scenario
     # this also checks if scenario is finished (will return response instead of component object)
     next_component = find_next_scenario_component(scenario)
 
-    # 3. Check if Scenario is finished
+    # 4. Check if entire Scenario is finished
     # if next_component is a ResultResponse -> means: no next index could be found -> means: Scenario is finished
     if isinstance(next_component, ResultResponse):
-        return next_component
-
-    # 4. Check with which component the simulation continues
-    # 4.1 Check if next component is a Question Component
-    # if next component is a Question:
-    if isinstance(next_component, QuestionCollection):
-
-        question_response = QuestionResponse(
-            question_collection=get_question_collection(scenario),
-            state=get_scenario_state_dto(scenario),
-            tasks=get_tasks_status(scenario.id),
-            members=get_member_report(scenario.team.id),
-        )
-        increase_scenario_counter(scenario)
-
-        return question_response
-
-    # 4.2 Check if next component is a Simulation Component
-    if isinstance(next_component, SimulationFragment):
-        # 4.2.1 Check if any events has occurred
-
-        # 4.2.2 Check if Simulation Fragment ended
-        if end_of_fragment(scenario):
-            logging.info(f"Fragment with index {scenario.state.counter} has ended.")
-            increase_scenario_counter(scenario)
-
-            # return next component
-            # don't know yet if recursive is the best solution
-            return continue_simulation(scenario, req)
-        # 4.2.3 Build response
-        return SimulationResponse(
+        scenario_response = next_component
+    # 5. Check with which component the simulation continues
+    # 5.1 Check if next component is a Simulation Component
+    elif isinstance(next_component, SimulationFragment):
+        scenario_response = SimulationResponse(
             actions=get_actions_from_fragment(next_component),
             tasks=get_tasks_status(scenario.id),
             state=get_scenario_state_dto(scenario),
             members=get_member_report(scenario.team.id),
         )
-
-    # 4.3 Check if next component is a Model Selection
-    if isinstance(next_component, ModelSelection):
-        increase_scenario_counter(scenario)
-        return ModelSelectionResponse(
+    # 5.2 Check if next component is a Question Component
+    elif isinstance(next_component, QuestionCollection):
+        scenario_response = QuestionResponse(
+            question_collection=get_question_collection(scenario),
+            state=get_scenario_state_dto(scenario),
+            tasks=get_tasks_status(scenario.id),
+            members=get_member_report(scenario.team.id),
+        )
+    # 5.3 Check if next component is a Model Selection
+    elif isinstance(next_component, ModelSelection):
+        scenario_response = ModelSelectionResponse(
             tasks=get_tasks_status(scenario.id),
             state=get_scenario_state_dto(scenario),
             members=get_member_report(scenario.team.id),
             models=next_component.models(),
         )
+
+    write_history(scenario, req, scenario_response.type)
+
+    # increase counter
+    increase_scenario_step_counter(scenario)
+    if scenario_response.type != "SIMULATION":
+        increase_scenario_component_counter(scenario)
+
+    return scenario_response

--- a/backend/app/src/util/question_util.py
+++ b/backend/app/src/util/question_util.py
@@ -5,7 +5,8 @@ from app.serializers.question_collection import QuestionCollectionSerializer
 
 def get_question_collection(scenario):
     question_collections = QuestionCollection.objects.get(
-        template_scenario_id=scenario.template_id, index=scenario.state.counter
+        template_scenario_id=scenario.template_id,
+        index=scenario.state.component_counter,
     )
     serializer = QuestionCollectionSerializer(question_collections)
 

--- a/backend/app/src/util/scenario_util.py
+++ b/backend/app/src/util/scenario_util.py
@@ -4,8 +4,10 @@ from app.dto.request import (
     SimulationRequest,
     QuestionRequest,
     ModelRequest,
+    StartRequest,
 )
 from app.dto.response import ActionDTO
+from history.models.history import History
 
 
 def check_indexes(data) -> bool:
@@ -36,6 +38,7 @@ def create_correct_request_model(request) -> ScenarioRequest:
         "SIMULATION": SimulationRequest,
         "QUESTION": QuestionRequest,
         "MODEL": ModelRequest,
+        "START": StartRequest,
     }
     for key, value in request_types.items():
         if request.data.get("type") == key:
@@ -44,6 +47,10 @@ def create_correct_request_model(request) -> ScenarioRequest:
 
 
 def handle_model_request(req, scenario):
+    pass
+
+
+def handle_start_request(req, scenario):
     pass
 
 
@@ -58,3 +65,15 @@ def get_actions_from_fragment(next_component) -> List[ActionDTO]:
         )
         for a in next_component.actions.values()
     ]
+
+
+def request_type_matches_previous_response_type(scenario, req) -> bool:
+
+    if scenario.state.step_counter == 0:
+        return req.type == "START"
+
+    # get last step from history
+    history = History.objects.get(
+        user_scenario_id=scenario.id, step_counter=scenario.state.step_counter - 1
+    )
+    return req.type == history.response_type

--- a/backend/app/src/util/user_scenario_util.py
+++ b/backend/app/src/util/user_scenario_util.py
@@ -24,7 +24,8 @@ def find_next_scenario_component(scenario):
     # add all components here
     components = [QuestionCollection, SimulationFragment, ModelSelection]
     query = dict(
-        index=scenario.state.counter, template_scenario_id=scenario.template_id
+        index=scenario.state.component_counter,
+        template_scenario_id=scenario.template_id,
     )
 
     for component in components:
@@ -47,10 +48,12 @@ def end_of_fragment(scenario) -> bool:
     returns: boolean
     """
     # todo philip: clean this up
-
-    fragment = SimulationFragment.objects.get(
-        template_scenario=scenario.template, index=scenario.state.counter
-    )
+    try:
+        fragment = SimulationFragment.objects.get(
+            template_scenario=scenario.template, index=scenario.state.component_counter
+        )
+    except:
+        return False
 
     tasks_done = Task.objects.filter(user_scenario=scenario, done=True)
 
@@ -65,6 +68,11 @@ def end_of_fragment(scenario) -> bool:
                     return False
 
 
-def increase_scenario_counter(scenario, increase_by=1):
-    scenario.state.counter = scenario.state.counter + increase_by
+def increase_scenario_component_counter(scenario, increase_by=1):
+    scenario.state.component_counter = scenario.state.component_counter + increase_by
+    scenario.state.save()
+
+
+def increase_scenario_step_counter(scenario, increase_by=1):
+    scenario.state.step_counter = scenario.state.step_counter + increase_by
     scenario.state.save()

--- a/backend/history/models/history.py
+++ b/backend/history/models/history.py
@@ -8,25 +8,25 @@ class History(models.Model):
         UserScenario, on_delete=models.CASCADE, related_name="history"
     )
 
-    request_type = models.TextField(max_length=32)
-    response_type = models.TextField(max_length=32)
+    request_type = models.TextField(max_length=32, default="", null=True)
+    response_type = models.TextField(max_length=32, default="", null=True)
 
     timestamp = models.DateTimeField(auto_now=True)
 
     # State
-    component_counter = models.PositiveIntegerField()
-    step_counter = models.PositiveIntegerField()
-    day = models.PositiveIntegerField()
-    cost = models.FloatField()
+    component_counter = models.PositiveIntegerField(null=True)
+    step_counter = models.PositiveIntegerField(null=True)
+    day = models.PositiveIntegerField(null=True)
+    cost = models.FloatField(null=True)
 
     # Tasks
-    tasks_todo = models.PositiveIntegerField()
-    task_done = models.PositiveIntegerField()
-    tasks_unit_tested = models.PositiveIntegerField()
-    tasks_integration_tested = models.PositiveIntegerField()
-    tasks_bug_discovered = models.PositiveIntegerField()
-    tasks_bug_undiscovered = models.PositiveIntegerField()
-    tasks_done_wrong_specification = models.PositiveIntegerField()
+    tasks_todo = models.PositiveIntegerField(null=True)
+    task_done = models.PositiveIntegerField(null=True)
+    tasks_unit_tested = models.PositiveIntegerField(null=True)
+    tasks_integration_tested = models.PositiveIntegerField(null=True)
+    tasks_bug_discovered = models.PositiveIntegerField(null=True)
+    tasks_bug_undiscovered = models.PositiveIntegerField(null=True)
+    tasks_done_wrong_specification = models.PositiveIntegerField(null=True)
 
     # Question
     question_collection = models.ForeignKey(

--- a/backend/history/models/history.py
+++ b/backend/history/models/history.py
@@ -8,12 +8,14 @@ class History(models.Model):
         UserScenario, on_delete=models.CASCADE, related_name="history"
     )
 
-    type = models.TextField(max_length=32)
+    request_type = models.TextField(max_length=32)
+    response_type = models.TextField(max_length=32)
 
     timestamp = models.DateTimeField(auto_now=True)
 
     # State
-    counter = models.PositiveIntegerField()
+    component_counter = models.PositiveIntegerField()
+    step_counter = models.PositiveIntegerField()
     day = models.PositiveIntegerField()
     cost = models.FloatField()
 

--- a/backend/history/write.py
+++ b/backend/history/write.py
@@ -9,14 +9,16 @@ from history.models.question import HistoryQuestion, HistoryAnswer
 from history.models.member import HistoryMemberChanges, HistoryMemberStatus
 
 
-def write_history(scenario, request: ScenarioRequest):
+def write_history(scenario, request: ScenarioRequest, response_type):
 
     # 1 Write basic stats into a new history entry
     try:
         h = History(
-            type=request.type,
+            request_type=request.type,
+            response_type=response_type,
             user_scenario=scenario,
-            counter=scenario.state.counter,
+            component_counter=scenario.state.component_counter,
+            step_counter=scenario.state.step_counter,
             day=scenario.state.day,
             cost=scenario.state.cost,
             model=scenario.model,


### PR DESCRIPTION
### Die continue_simulation function prüft jetzt ob der type der Request der gleiche ist wie der type der vorherigen Response, und wirft einen Fehler mit entschprechender HTTP Response.

### Erweiterung der History:
#### Umbenennungen:
- counter -> component counter
- type -> request type

#### Neu-Implementierung:
- step_counter: Counter für jeden einzelnen Schritt des Scenarios
- response_type: type der Response in diesem Scenario Schritt

So kann genau nachvollzogen werden in welchem Schritt der User war/ist und welche Request und welche Response gesendet wurden
![image](https://user-images.githubusercontent.com/62027207/172000356-4a710523-638e-4713-8fea-2f0cb482246b.png)
