### PR TITLE
feature: #397 Added Team Average Stats to Responses

### DIFF
--- a/backend/app/dto/response.py
+++ b/backend/app/dto/response.py
@@ -64,6 +64,12 @@ class ActionDTO(BaseModel):
     upper_limit: Optional[int] = None
 
 
+class TeamStatsDTO(BaseModel):
+    motivation: float
+    familiarity: float
+    stress: float
+
+
 class ScenarioResponse(BaseModel, ABC):
     """
     This is the abstract response class that provides all data
@@ -77,6 +83,7 @@ class ScenarioResponse(BaseModel, ABC):
     state: ScenarioStateDTO
     tasks: TasksStatusDTO
     members: List[MemberDTO]
+    team: TeamStatsDTO
     text = ""
 
 

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.core.validators import MaxValueValidator, MinValueValidator
 
 from app.dto.request import Workpack
+from app.dto.response import TeamStatsDTO
 from app.models.task import TaskStatus, CachedTasks, Task
 from app.models.user_scenario import UserScenario
 from app.src.util.util import probability
@@ -44,6 +45,38 @@ class Team(models.Model):
     def management_skill(self):
         """Returns the team's management skill."""
         return 0.5  # TODO: implement
+
+    def motivation(self, members=None):
+        """Returns the team's motivation."""
+        if members is None:
+            members = Member.objects.filter(team_id=self.id)
+        if len(members) == 0:
+            return 0
+        return mean([m.motivation for m in members])
+
+    def familiarity(self, members=None):
+        """Returns the team's familiarity."""
+        if members is None:
+            members = Member.objects.filter(team_id=self.id)
+        if len(members) == 0:
+            return 0
+        return mean([m.familiarity for m in members])
+
+    def stress(self, members=None):
+        """Returns the team's stress."""
+        if members is None:
+            members = Member.objects.filter(team_id=self.id)
+        if len(members) == 0:
+            return 0
+        return mean([m.stress for m in members])
+
+    def stats(self, members=None) -> TeamStatsDTO:
+        """Returns all team stats."""
+        return TeamStatsDTO(
+            motivation=self.motivation(members),
+            familiarity=self.familiarity(members),
+            stress=self.stress(members),
+        )
 
     # increases familiarity with the project for each member
     def meeting(self, scenario, members, work_hours, cached_tasks) -> int:

--- a/backend/app/src/simulation.py
+++ b/backend/app/src/simulation.py
@@ -192,6 +192,7 @@ def continue_simulation(scenario: UserScenario, req) -> ScenarioResponse:
             tasks=get_tasks_status(scenario.id),
             state=get_scenario_state_dto(scenario),
             members=get_member_report(scenario.team.id),
+            team=scenario.team.stats(),
             text=next_component.text,
         )
     # 5.2 Check if next component is a Question Component
@@ -202,6 +203,7 @@ def continue_simulation(scenario: UserScenario, req) -> ScenarioResponse:
             state=get_scenario_state_dto(scenario),
             tasks=get_tasks_status(scenario.id),
             members=get_member_report(scenario.team.id),
+            team=scenario.team.stats(),
             text=next_component.text,
         )
     # 5.3 Check if next component is a Model Selection
@@ -212,6 +214,7 @@ def continue_simulation(scenario: UserScenario, req) -> ScenarioResponse:
             state=get_scenario_state_dto(scenario),
             members=get_member_report(scenario.team.id),
             models=next_component.models(),
+            team=scenario.team.stats(),
             text=next_component.text,
         )
 

--- a/backend/history/util/result.py
+++ b/backend/history/util/result.py
@@ -35,6 +35,7 @@ def get_result_response(scenario: UserScenario) -> ResultResponse:
                 tasks_integration_tested=result.tasks_integration_tested,
                 tasks_bug=result.tasks_bug_discovered,
             ),
+            team=scenario.team.stats(),
             members=get_member_report(scenario.team.id),
             total_score=result.total_score,
             quality_score=result.quality_score,


### PR DESCRIPTION
All responses now contain an object `team` that holds the team's averages for motivation, familiarity and stress
```json
{
    "team": {
        "motivation": 0.75,
        "familiarity": 0.65,
        "stress": 0.1
    },
}
```