### PR TITLE
feature: #484 Create Many Users Endpoint

### DIFF
--- a/backend/app/api/endpoints.py
+++ b/backend/app/api/endpoints.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from app.api.security.create_users import UserCreationView
 
 from app.api.views.question_collection import QuestionCollectionView
 from app.api.views.user_scenario import UserScenarioViews
@@ -38,6 +39,7 @@ urlpatterns = [
     path("authenticated", CheckAuthenticatedView.as_view(), name="authenticated"),
     path("register", RegisterView.as_view(), name="register"),
     path("user", UserView.as_view()),
+    path("user/create-many", UserCreationView.as_view()),
     path("user/<str:username>", UserView.as_view()),
     # template scenario
     path("template-scenario", TemplateScenarioView.as_view()),

--- a/backend/app/api/security/create_users.py
+++ b/backend/app/api/security/create_users.py
@@ -1,0 +1,67 @@
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+from app.decorators.decorators import allowed_roles
+
+from custom_user.models import User
+
+import random
+import string
+import logging
+
+"""
+Views for user authentication (login, logout, creation, csrf-token handling)
+"""
+
+
+class UserCreationView(APIView):
+    @allowed_roles(["staff"])
+    def post(self, request, format=None):
+        data = self.request.data
+
+        # Getting data from request
+        prefix = data.get("prefix", "user")
+        amount = data.get("count", 1)
+        pw_len = data.get("pw-length", 8)
+        start_index = data.get("start-index", 1)
+
+        if start_index < 0:
+            start_index = 0
+
+        if pw_len < 5:
+            pw_len = 5
+
+        def generate_password():
+            return "".join(
+                [
+                    random.choice(string.ascii_letters + string.digits)
+                    for _ in range(pw_len)
+                ]
+            )
+
+        users = [
+            {"username": f"{prefix}{i}", "password": generate_password()}
+            for i in range(start_index, start_index + amount)
+        ]
+
+        for user in users:
+            if User.objects.filter(username=user.get("username")).exists():
+                return Response(
+                    {"error": f"Username {user.get('username')} already exists"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        try:
+            for user in users:
+                User.objects.create(**user)
+        except Exception as e:
+            logging.error(f"{e.__class__.__name__} occured when creating users.")
+            return Response(
+                {"error": f"{e.__class__.__name__}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return Response(
+            data={"status": "success", "data": users}, status=status.HTTP_201_CREATED
+        )
+


### PR DESCRIPTION
The Endpoint 

POST */api/user/create-many*

allows to create many users according to a specified pattern. Two important arguments can be specified in the body: 
```json
{
    "prefix": "pm_22_",
    "count": 3
}
```
This will create 3 users starting with `pm_22_`. The details will be sent in the body of the response:

```json
{
    "status": "success",
    "data": [
        {
            "username": "pm_22_1",
            "password": "XDP1NaMz"
        },
        {
            "username": "pm_22_2",
            "password": "EFjsPDbB"
        },
        {
            "username": "pm_22_3",
            "password": "Hqgn01xt"
        }
    ]
}
```


You can add more specifications: 

`pw-length`: The length of the passwords (defaults to 8, must be at least 5)
`start-index`: The starting index after the prefix (defaults to 1) 
```json
{
    "prefix": "sose22_",
    "count": 2,
    "pw-length": 5,
    "start-index": 120
}
```

Response:

```json
{
    "status": "success",
    "data": [
        {
            "username": "sose22_120",
            "password": "CvAHH"
        },
        {
            "username": "sose22_121",
            "password": "84GQz"
        }
    ]
}
```
